### PR TITLE
Fix PdfAsset width/height handling

### DIFF
--- a/autobasedoc/pdfimage.py
+++ b/autobasedoc/pdfimage.py
@@ -164,7 +164,7 @@ class PdfAsset(Flowable):
 
     it can e used like a `reportlab.platypus.Flowable()`
     """
-    def __init__(self,fname,width=None,height=None,kind='direct'):
+    def __init__(self, fname, width=None, height=None, kind='direct'):
 
         self.page = PdfReader(fname=fname, decompress=False).pages[0]
         self.xobj = pagexobj(self.page)
@@ -179,13 +179,15 @@ class PdfAsset(Flowable):
         if not self.imageHeight:
             self.imageHeight = self._h
         self.__ratio = float(self.imageWidth)/self.imageHeight
-        if kind in ['direct','absolute'] or width==None or height==None:
+        if kind in ['direct', 'absolute'] or width is None or height is None:
             self.drawWidth = width or self.imageWidth
             self.drawHeight = height or self.imageHeight
-        elif kind in ['bound','proportional']:
-            factor = min(float(width)/self._w,float(height)/self._h)
-            self.drawWidth = self._w*factor
-            self.drawHeight = self._h*factor
+        elif kind in ['bound', 'proportional']:
+            factor = min(float(width) / self._w, float(height) / self._h)
+            self.drawWidth = self._w * factor
+            self.drawHeight = self._h * factor
+        self.width = self.drawWidth
+        self.height = self.drawHeight
 
     def wrap(self, width, height):
         return self.imageWidth, self.imageHeight

--- a/tests/flowables.py
+++ b/tests/flowables.py
@@ -66,10 +66,7 @@ def create_bookmark(text, level):
     return ar.Bookmark(text, level)
 
 def create_image(url, width, height):
-    flow = PdfAsset(url, width=width * ar.cm, height=height * ar.cm)
-    # NOTE next line should be repaired in pdfimage !!!
-    flow.width = width * ar.cm
-    return flow
+    return PdfAsset(url, width=width * ar.cm, height=height * ar.cm)
 
 def create_header(headerText, rightHeaderLines, logoUrl):
     header = Header(headerMarginTop=0.9, debug=False)


### PR DESCRIPTION
## Summary
- ensure `PdfAsset` sets `width` and `height` so calling code doesn't patch it
- simplify `create_image` helper in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429d52927c8326b9ac7146822d5fc9