### PR TITLE
Fix invalid requirement spec

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ reportlab>=3.4.0
 pdfrw>=0.4
 svglib>=0.8.1
 cycler>=0.10.0
-matplotlib>=2.0.2<3.0.0
+matplotlib>=2.0.2,<3.0.0
 img2pdf


### PR DESCRIPTION
## Summary
- correct matplotlib version syntax in requirements.txt

## Testing
- `pytest -q` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6842f4f494388326b240167928afffec