### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ cd autobasedoc
 pip install -e .
 ```
 
+### Environment Setup Script
+If you want to create a local virtual environment with all dependencies, you can
+run the helper script:
+
+```bash
+./setup_env.sh
+```
+
 ### Requirements
 - Python 3.6+
 - ReportLab 3.5+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ reportlab>=3.4.0
 pdfrw>=0.4
 svglib>=0.8.1
 cycler>=0.10.0
-matplotlib>=2.0.2<3.0.0
+matplotlib>=2.0.2,<3.0.0
 img2pdf

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Simple environment setup script for AutoBaseDoc
+# Creates a virtual environment and installs dependencies
+
+set -e
+
+ENV_DIR=".venv"
+PYTHON=${PYTHON:-python3}
+
+if [ ! -x "$(command -v $PYTHON)" ]; then
+  echo "Python interpreter '$PYTHON' not found." >&2
+  exit 1
+fi
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "$ENV_DIR" ]; then
+  $PYTHON -m venv "$ENV_DIR"
+fi
+
+# Activate the environment
+source "$ENV_DIR/bin/activate"
+
+# Upgrade pip and install requirements
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# Show some environment info
+python info.py
+
+echo "Virtual environment setup complete."


### PR DESCRIPTION
## Summary
- introduce `setup_env.sh` for creating a virtual environment and installing dependencies
- document the setup script in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6842f4f494388326b240167928afffec