### PR TITLE
Improve font handling and add docs

### DIFF
--- a/autobasedoc/autoplot.py
+++ b/autobasedoc/autoplot.py
@@ -53,11 +53,11 @@ fontprop = None
 
 
 def autoPdfImage(func):
-    """
-    decorator for the autoplot module
+    """Decorator returning :class:`PdfImage` instances for plots.
 
-    returns two PdfImage objects if wrapped plt-function obeys the principle
-    demonstated in following minimal example::
+    The wrapped matplotlib function must return a tuple ``(fig, legend_fig,
+    legend)``.  Two :class:`PdfImage` objects – the plot and its legend – are
+    produced.  Example::
 
         @autoPdfImage
         def my_plot(canvaswidth=5): #[inch]
@@ -127,11 +127,10 @@ def autoPdfImage(func):
 
 
 def autoPdfImg(func):
-    """
-    decorator for the autoplot module
+    """Decorator returning a single :class:`PdfImage` for a plot.
 
-    returns one PdfImage objects if wrapped plt-function obeys the principle
-    demonstated in following minimal example::
+    The wrapped function should return a matplotlib ``Figure``.  The figure is
+    saved to a PDF byte buffer and returned as a :class:`PdfImage`.  Example::
 
         @autoPdfImg
         def my_plot(canvaswidth=5): #[inch]
@@ -193,9 +192,14 @@ def autoPdfImg(func):
 
 
 def full_extent(ax, pad=0.0):
-    """
-    Get the full extent of an axes, including axes labels, tick labels, and
-    titles.
+    """Return the bounding box of an ``Axes`` including tick and axis labels.
+
+    Parameters
+    ----------
+    ax : :class:`matplotlib.axes.Axes`
+        Target axes instance.
+    pad : float, optional
+        Padding factor applied to the final bounding box.
     """
     # For text objects, we need to draw the figure first, otherwise the extents
     # are undefined.

--- a/autobasedoc/fonts.py
+++ b/autobasedoc/fonts.py
@@ -1,13 +1,8 @@
-"""
-fonts
-=====
+"""Font utilities used throughout :mod:`autobasedoc`.
 
-.. module:: fonts
-   :platform: Unix, Windows
-   :synopsis: font utils
-
-.. moduleauthor:: Johannes Eckstein
-
+This module centralises handling of font registration and font directories.  The
+functions are thin wrappers around the ReportLab API and are used by
+``autorpt`` and the example scripts.
 """
 
 import os
@@ -18,25 +13,31 @@ from reportlab.pdfbase.pdfmetrics import getFont
 from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.lib.fonts import addMapping
 
+# directory containing the bundled font files
+__font_dir__ = os.path.realpath(os.path.join(os.path.dirname(__file__), "fonts"))
+
 
 def registerFont(faceName, afm, pfb):
+    """Register a Type1 font pair.
+
+    Parameters
+    ----------
+    faceName : str
+        Name used by ReportLab for the font.
+    afm : str
+        Base filename of the AFM metrics file located in ``__font_dir__``.
+    pfb : str
+        Base filename of the PFB font file located in ``__font_dir__``.
+
+    Notes
+    -----
+    The AFM metrics distributed with Matplotlib are paired with PFB files from
+    ReportLab to create embedded Type1 fonts.  Previously this function used
+    ``str.join`` which raised a ``TypeError``.  The path handling has been
+    corrected.
     """
-    Helvetica BUT AS AFM
-
-    The below section is NOT equal to::
-
-        _baseFontName  ='Helvetica'
-        _baseFontNameB ='Helvetica-Bold'
-        _baseFontNameI ='Helvetica-Oblique'
-        _baseFontNameBI='Helvetica-BoldOblique'
-
-    we will mapp afm files from matplotlib with pfb files from reportlab
-
-    this will give embedded Type1 Face Fonts
-
-    """
-    afm = os.path.join(__font_dir__, "".join(afm, ".afm"))
-    pfb = os.path.join(__font_dir__, "".join(pfb, ".pfb"))
+    afm = os.path.join(__font_dir__, f"{afm}.afm")
+    pfb = os.path.join(__font_dir__, f"{pfb}.pfb")
 
     face = pdfmetrics.EmbeddedType1Face(afm, pfb)
     pdfmetrics.registerTypeFace(face)
@@ -50,9 +51,7 @@ def setTtfFonts(familyName,
                 bold=(None, None),
                 italic=(None, None),
                 bold_italic=(None, None)):
-    """
-    Sets fonts for True Type Fonts
-    """
+    """Register a TrueType font family with ReportLab."""
     normalName, normalFile = normal
     boldName, boldFile = bold
     italicName, italicFile = italic

--- a/autobasedoc/pdfimage.py
+++ b/autobasedoc/pdfimage.py
@@ -35,29 +35,33 @@ from svglib.svglib import svg2rlg
 
 import img2pdf
 
-def convert_px_to_pdf_image_obj(img_path):
-    """
-    convert png image to pdf byte object
-    output can be passed to PdfImage
+def convert_px_to_pdf_image_obj(img_path: str) -> BytesIO:
+    """Convert a PNG image to a PDF byte stream.
+
+    Parameters
+    ----------
+    img_path : str
+        Path to the PNG file.
+
+    Returns
+    -------
+    io.BytesIO
+        Buffer containing the PDF representation.  The buffer can be passed to
+        :class:`PdfImage`.
     """
     return BytesIO(img2pdf.convert(img_path))
 
-def form_xo_reader(imgdata):
+def form_xo_reader(imgdata: BytesIO):
+    """Create a ``pdfrw`` XObject from a PDF byte buffer."""
     page, = PdfReader(imgdata).pages
     return pagexobj(page)
 
-def getSvg(path):
-    """
-    return `reportlab.graphics.shapes.Drawing()` object
-    with the contents of the SVG specified by path
-    """
+def getSvg(path: str):
+    """Load an SVG file into a ReportLab :class:`~reportlab.graphics.shapes.Drawing`."""
     return svg2rlg(path)
 
-def scaleDrawing(drawing,factor,showBoundary=False):
-    """
-    scale a reportlab.graphics.shapes.Drawing() object,
-    leaving its aspect ratio unchanged
-    """
+def scaleDrawing(drawing, factor: float, showBoundary: bool = False):
+    """Scale a drawing while preserving aspect ratio."""
     sx=sy=factor
     drawing.width,drawing.height = drawing.minWidth()*sx, drawing.height*sy
     drawing.scale(sx,sy)
@@ -66,10 +70,8 @@ def scaleDrawing(drawing,factor,showBoundary=False):
 
     return drawing
 
-def getScaledSvg(path,factor):
-    """
-    get a scaled svg image from file
-    """
+def getScaledSvg(path: str, factor: float):
+    """Load and scale an SVG file."""
     drawing = getSvg(path)
 
     return scaleDrawing(drawing,factor)


### PR DESCRIPTION
## Summary
- document pdf image helpers and plot decorators
- expand font helper docs
- fix font path handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f7ba331483269ac458f7eab9b93b