### PR TITLE
Include font files in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include autobasedoc/fonts *

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,13 @@ for dirname, dirnames, filenames in os.walk(name):
 package_dir = {name: name}
 
 # Data files used e.g. in tests
-package_data = {} #{name: [os.path.join(name, 'tests', 'prt.txt')]}
+package_data = {
+    'autobasedoc': [
+        'fonts/*.ttf',
+        'fonts/*.afm',
+        'fonts/*.pfb'
+    ]
+}  # {name: [os.path.join(name, 'tests', 'prt.txt')]}
 
 # The current version number - MSI accepts only version X.X.X
 exec(open(os.path.join(name, 'version.py')).read())


### PR DESCRIPTION
## Summary
- ensure bundled fonts are shipped with the package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552bb49f048326a55b2683c5b98074